### PR TITLE
Complete community health files (LICENSE, CoC, SECURITY, templates)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,31 @@
+name: Bug Report
+description: Report a reproducible problem in this starter template.
+title: "[Bug]: "
+labels:
+  - bug
+body:
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: Describe the problem and expected behavior.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction
+      description: List the smallest steps needed to reproduce the problem.
+      placeholder: |
+        1. Run `yarn install`
+        2. Run `yarn dev`
+        3. See error
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Include Node.js, Yarn, operating system, browser, and any relevant tool versions.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Security reports
+    url: https://github.com/everettmorgan/base-vue/security/advisories/new
+    about: Please report suspected vulnerabilities privately.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,20 @@
+name: Feature Request
+description: Suggest an improvement to this starter template.
+title: "[Feature]: "
+labels:
+  - enhancement
+body:
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: Describe the improvement and why it belongs in this template.
+    validations:
+      required: true
+  - type: textarea
+    id: details
+    attributes:
+      label: Details
+      description: Describe the proposed behavior, tradeoffs, and alternatives.
+    validations:
+      required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,14 @@
+## Summary
+
+- 
+
+## Verification
+
+- [ ] `yarn lint`
+- [ ] `yarn typecheck`
+- [ ] `yarn test`
+- [ ] `yarn build`
+
+## Notes
+
+-

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,11 @@
+# Security Policy
+
+## Supported Versions
+
+This starter template is maintained on the default branch. Security fixes are applied to `main`.
+
+## Reporting a Vulnerability
+
+Please report security issues privately through GitHub Security Advisories when available, or contact the maintainer directly if advisories are not available for your fork.
+
+Do not open public issues for suspected vulnerabilities.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,21 @@
+# Code of Conduct
+
+## Our Standard
+
+This project is a small starter template, but collaboration should still be direct, respectful, and focused on improving the work.
+
+Participants are expected to:
+
+- Use welcoming and inclusive language.
+- Respect differing viewpoints and experience levels.
+- Give and receive technical feedback constructively.
+- Keep discussion focused on the repository and its goals.
+- Avoid harassment, personal attacks, and other disruptive behavior.
+
+## Enforcement
+
+The maintainer may edit, hide, or remove comments, issues, pull requests, or other contributions that do not meet this standard. The maintainer may also block participants who repeatedly disrupt the project.
+
+## Reporting
+
+Report conduct concerns to the maintainer privately. Security issues should be reported through the repository security policy instead of public issues.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,25 @@
+# Contributing
+
+Thanks for improving this starter template.
+
+## Workflow
+
+1. Open an issue for larger changes before implementation.
+2. Keep pull requests focused on one concern.
+3. Update tests and documentation when behavior changes.
+4. Run the local validation suite before opening a pull request.
+
+```sh
+yarn lint
+yarn typecheck
+yarn test
+yarn build
+```
+
+## Pull Requests
+
+Pull requests into `main` must pass CI and CodeQL before merge. The repository uses squash merges, so write the pull request title and description as the durable change summary.
+
+## Security
+
+Do not open public issues for suspected vulnerabilities. Follow [SECURITY.md](.github/SECURITY.md).

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2021 Everett Morgan
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -154,4 +154,4 @@ yarn build
 
 ## License
 
-No license file is currently present. All rights are reserved unless a license is added.
+MIT (c) Everett Morgan. See [LICENSE](LICENSE).


### PR DESCRIPTION
Brings base-vue's community standards to 100%, matching base-ts. Adds the files GitHub's Community Standards checklist was missing:

- **LICENSE** — MIT (c) Everett Morgan (matches base-ts)
- **CODE_OF_CONDUCT.md**
- **CONTRIBUTING.md** — with base-vue's `lint`/`typecheck`/`test`/`build` validation suite
- **.github/SECURITY.md**
- **.github/PULL_REQUEST_TEMPLATE.md**
- **.github/ISSUE_TEMPLATE/** — bug + feature YAML issue forms and `config.yml`

Also updates the README license section to reference the new LICENSE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)